### PR TITLE
[circleci] make targets for publishing artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,6 +253,22 @@ jobs:
           python-environment: test-macos-py<< parameters.python-version >>
           tensorflow-version: << parameters.tensorflow-version >>
 
+  store:
+    docker:
+      - image: tfencrypted/tf-big:deploy
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./out
+      - run:
+          name: List content to be stored
+          command: |
+            tree ./out/wheelhouse
+      - store_artifacts:
+          path: ./out/wheelhouse
+          destination: wheelhouse
+
   deploy:
     docker:
       - image: tfencrypted/tf-big:deploy
@@ -262,16 +278,20 @@ jobs:
       - attach_workspace:
           at: ./out
       - run:
-          name: TODO
+          name: Upload to PyPI
           command: |
-            tree ./out
-      - store_artifacts:
-          path: ./out/wheelhouse
-          destination: wheelhouse
+            tree ./out/wheelhouse
+            DIR_WHEEL=./out/wheelhouse make push-wheels
 
 workflows:
   version: 2
   
+  # these workflows implement the following logic:
+  # - non-master branch: run quick tests
+  # - master branch: build, test, and store wheels
+  # - non-semver tag: build, test, and store wheels
+  # - semver tag: build, test, store, and deploy wheels 
+
   quicktest:
     jobs:
       - build-linux:
@@ -281,6 +301,8 @@ workflows:
           filters:
             branches:
               ignore: master
+            tags:
+              ignore: /.*/
 
       - bundle-linux:
           name: bundle-linux-py3.6
@@ -290,6 +312,8 @@ workflows:
           filters:
             branches:
               ignore: master
+            tags:
+              ignore: /.*/
 
       - whltest-linux:
           name: whltest-linux-py3.6-tf1.14.0
@@ -300,6 +324,8 @@ workflows:
           filters:
             branches:
               ignore: master
+            tags:
+              ignore: /.*/
 
   linux-py3.5:
     jobs:
@@ -310,6 +336,8 @@ workflows:
           filters:
             branches:
               only: master
+            tags:
+              only: /.*/
       - build-linux:
           name: build-linux-py3.5-tf1.13.2
           python-version: "3.5"
@@ -317,6 +345,8 @@ workflows:
           filters:
             branches:
               only: master
+            tags:
+              only: /.*/
       - build-linux:
           name: build-linux-py3.5-tf1.14.0
           python-version: "3.5"
@@ -324,6 +354,8 @@ workflows:
           filters:
             branches:
               only: master
+            tags:
+              only: /.*/
 
       - bundle-linux:
           name: bundle-linux-py3.5
@@ -332,6 +364,11 @@ workflows:
             - build-linux-py3.5-tf1.13.1
             - build-linux-py3.5-tf1.13.2
             - build-linux-py3.5-tf1.14.0
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /.*/
 
       - whltest-linux:
           name: whltest-linux-py3.5-tf1.13.1
@@ -339,26 +376,64 @@ workflows:
           tensorflow-version: "1.13.1"
           requires:
             - bundle-linux-py3.5
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /.*/
       - whltest-linux:
           name: whltest-linux-py3.5-tf1.13.2
           python-version: "3.5"
           tensorflow-version: "1.13.2"
           requires:
             - bundle-linux-py3.5
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /.*/
       - whltest-linux:
           name: whltest-linux-py3.5-tf1.14.0
           python-version: "3.5"
           tensorflow-version: "1.14.0"
           requires:
             - bundle-linux-py3.5
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /.*/
 
-      - deploy:
-          name: deploy-linux-py3.5
+      - store:
+          name: store-linux-py3.5
           requires:
             - whltest-linux-py3.5-tf1.13.1
             - whltest-linux-py3.5-tf1.13.2
             - whltest-linux-py3.5-tf1.14.0
           filters:
+            branches:
+              only: master
+            tags:
+              only: /.*/
+
+      - hold:
+          type: approval
+          name: hold-linux-py3.5
+          requires:
+           - store-linux-py3.5
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^(?:[0-9]+)\.(?:[0-9]+)\.(?:[0-9]+)(?:(\-rc[0-9]+)?)$/
+
+      - deploy:
+          name: deploy-linux-py3.5
+          requires:
+            - hold-linux-py3.5
+          filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /^(?:[0-9]+)\.(?:[0-9]+)\.(?:[0-9]+)(?:(\-rc[0-9]+)?)$/
 
@@ -371,6 +446,8 @@ workflows:
           filters:
             branches:
               only: master
+            tags:
+              only: /.*/
       - build-linux:
           name: build-linux-py3.6-tf1.13.2
           python-version: "3.6"
@@ -378,6 +455,8 @@ workflows:
           filters:
             branches:
               only: master
+            tags:
+              only: /.*/
       - build-linux:
           name: build-linux-py3.6-tf1.14.0
           python-version: "3.6"
@@ -385,6 +464,8 @@ workflows:
           filters:
             branches:
               only: master
+            tags:
+              only: /.*/
 
       - bundle-linux:
           name: bundle-linux-py3.6
@@ -393,6 +474,11 @@ workflows:
             - build-linux-py3.6-tf1.13.1
             - build-linux-py3.6-tf1.13.2
             - build-linux-py3.6-tf1.14.0
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /.*/
 
       - whltest-linux:
           name: whltest-linux-py3.6-tf1.13.1
@@ -400,26 +486,64 @@ workflows:
           tensorflow-version: "1.13.1"
           requires:
             - bundle-linux-py3.6
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /.*/
       - whltest-linux:
           name: whltest-linux-py3.6-tf1.13.2
           python-version: "3.6"
           tensorflow-version: "1.13.2"
           requires:
             - bundle-linux-py3.6
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /.*/
       - whltest-linux:
           name: whltest-linux-py3.6-tf1.14.0
           python-version: "3.6"
           tensorflow-version: "1.14.0"
           requires:
             - bundle-linux-py3.6
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /.*/
 
-      - deploy:
-          name: deploy-linux-py3.6
+      - store:
+          name: store-linux-py3.6
           requires:
             - whltest-linux-py3.6-tf1.13.1
             - whltest-linux-py3.6-tf1.13.2
             - whltest-linux-py3.6-tf1.14.0
           filters:
+            branches:
+              only: master
+            tags:
+              only: /.*/
+
+      - hold:
+          type: approval
+          name: hold-linux-py3.6
+          requires:
+           - store-linux-py3.6
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^(?:[0-9]+)\.(?:[0-9]+)\.(?:[0-9]+)(?:(\-rc[0-9]+)?)$/
+
+      - deploy:
+          name: deploy-linux-py3.6
+          requires:
+            - hold-linux-py3.6
+          filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /^(?:[0-9]+)\.(?:[0-9]+)\.(?:[0-9]+)(?:(\-rc[0-9]+)?)$/
 
@@ -432,6 +556,8 @@ workflows:
           filters:
             branches:
               only: master
+            tags:
+              only: /.*/
       - build-macos:
           name: build-macos-py3.6-tf1.13.2
           python-version: "3.6"
@@ -439,6 +565,8 @@ workflows:
           filters:
             branches:
               only: master
+            tags:
+              only: /.*/
       - build-macos:
           name: build-macos-py3.6-tf1.14.0
           python-version: "3.6"
@@ -446,6 +574,8 @@ workflows:
           filters:
             branches:
               only: master
+            tags:
+              only: /.*/
 
       - bundle-macos:
           name: bundle-macos-py3.6
@@ -454,6 +584,11 @@ workflows:
             - build-macos-py3.6-tf1.13.1
             - build-macos-py3.6-tf1.13.2
             - build-macos-py3.6-tf1.14.0
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /.*/
 
       - whltest-macos:
           name: whltest-macos-py3.6-tf1.13.1
@@ -461,25 +596,63 @@ workflows:
           tensorflow-version: "1.13.1"
           requires:
             - bundle-macos-py3.6
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /.*/
       - whltest-macos:
           name: whltest-macos-py3.6-tf1.13.2
           python-version: "3.6"
           tensorflow-version: "1.13.2"
           requires:
             - bundle-macos-py3.6
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /.*/
       - whltest-macos:
           name: whltest-macos-py3.6-tf1.14.0
           python-version: "3.6"
           tensorflow-version: "1.14.0"
           requires:
             - bundle-macos-py3.6
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /.*/
 
-      - deploy:
-          name: deploy-macos-py3.6
+      - store:
+          name: store-macos-py3.6
           requires:
             - whltest-macos-py3.6-tf1.13.1
             - whltest-macos-py3.6-tf1.13.2
             - whltest-macos-py3.6-tf1.14.0
           filters:
+            branches:
+              only: master
+            tags:
+              only: /.*/
+
+      - hold:
+          type: approval
+          name: hold-macos-py3.6
+          requires:
+           - store-macos-py3.6
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^(?:[0-9]+)\.(?:[0-9]+)\.(?:[0-9]+)(?:(\-rc[0-9]+)?)$/
+
+      - deploy:
+          name: deploy-macos-py3.6
+          requires:
+            - hold-macos-py3.6
+          filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /^(?:[0-9]+)\.(?:[0-9]+)\.(?:[0-9]+)(?:(\-rc[0-9]+)?)$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,6 +358,9 @@ workflows:
             - whltest-linux-py3.5-tf1.13.1
             - whltest-linux-py3.5-tf1.13.2
             - whltest-linux-py3.5-tf1.14.0
+          filters:
+            tags:
+              only: /^(?:[0-9]+)\.(?:[0-9]+)\.(?:[0-9]+)(?:(\-rc[0-9]+)?)$/
 
   linux-py3.6:
     jobs:
@@ -416,6 +419,9 @@ workflows:
             - whltest-linux-py3.6-tf1.13.1
             - whltest-linux-py3.6-tf1.13.2
             - whltest-linux-py3.6-tf1.14.0
+          filters:
+            tags:
+              only: /^(?:[0-9]+)\.(?:[0-9]+)\.(?:[0-9]+)(?:(\-rc[0-9]+)?)$/
 
   macos-py3.6:
     jobs:
@@ -474,3 +480,6 @@ workflows:
             - whltest-macos-py3.6-tf1.13.1
             - whltest-macos-py3.6-tf1.13.2
             - whltest-macos-py3.6-tf1.14.0
+          filters:
+            tags:
+              only: /^(?:[0-9]+)\.(?:[0-9]+)\.(?:[0-9]+)(?:(\-rc[0-9]+)?)$/

--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,12 @@ fmt:
 lint:
 	cd tf_big && find . -iname *.h -o -iname *.cc | xargs cpplint --filter=-legal/copyright
 
-.PHONY: clean test build bundle pytest fmt lint
+download-wheels:
+	rm -rf ./wheelhouse
+	mkdir -p ./wheelhouse
+	DESTDIR=./wheelhouse python ./artifacts.py
+
+push-wheels:
+	python -m twine upload wheelhouse/*.whl
+
+.PHONY: clean test build bundle pytest fmt lint download-wheels push-wheels

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+DIR_TAGGED ?= ./tagged
+DIR_WHEEL ?= ./wheelhouse
+
 .bazelrc:
 	TF_NEED_CUDA=0 ./configure.sh
 
@@ -8,12 +11,10 @@ clean:
 test: .bazelrc
 	bazel test ... --test_output=all
 
-DIR_TAGGED ?= ./tagged
 build: .bazelrc
 	mkdir -p $(DIR_TAGGED)
 	./build.sh $(DIR_TAGGED)
 
-DIR_WHEEL ?= ./wheelhouse
 bundle:
 	mkdir -p $(DIR_WHEEL)
 	./bundle.sh $(DIR_TAGGED) $(DIR_WHEEL)
@@ -28,11 +29,11 @@ lint:
 	cd tf_big && find . -iname *.h -o -iname *.cc | xargs cpplint --filter=-legal/copyright
 
 download-wheels:
-	rm -rf ./wheelhouse
-	mkdir -p ./wheelhouse
-	DESTDIR=./wheelhouse python ./artifacts.py
+	rm -rf $(DIR_WHEEL)
+	mkdir -p $(DIR_WHEEL)
+	DESTDIR=$(DIR_WHEEL) python ./artifacts.py
 
 push-wheels:
-	python -m twine upload wheelhouse/*.whl
+	python -m twine upload $(DIR_WHEEL)/*.whl
 
 .PHONY: clean test build bundle pytest fmt lint download-wheels push-wheels

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TF Big
 
-TF Big adds big number support to TensorFlow, allowing computaitons to be performed on arbitrary precision integers. Internally these are represented as variant tensors of [GMP](https://gmplib.org/) values, exposed in Python through the `tf_big.Tensor` wrapper for convenience. For importing and exporting, numbers are typically expressed as strings.
+TF Big adds big number support to TensorFlow, allowing computations to be performed on arbitrary precision integers. Internally these are represented as variant tensors of [GMP](https://gmplib.org/) values, exposed in Python through the `tf_big.Tensor` wrapper for convenience. For importing and exporting, numbers are typically expressed as strings.
 
 [![PyPI](https://img.shields.io/pypi/v/tf-big.svg)](https://pypi.org/project/tf-big/) [![CircleCI Badge](https://circleci.com/gh/tf-encrypted/tf-big/tree/master.svg?style=svg)](https://circleci.com/gh/tf-encrypted/tf-big/tree/master)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TF Big
 
-TF Big adds big number support to TensorFlow, allowing computations to be performed on arbitrary precision integers. Internally these are represented as variant tensors of [GMP](https://gmplib.org/) values, exposed in Python through the `tf_big.Tensor` wrapper for convenience. For importing and exporting, numbers are typically expressed as strings.
+TF Big adds big number support to TensorFlow, allowing computations to be performed on arbitrary precision integers. Internally these are represented as variant tensors of [GMP](https://gmplib.org/) values, and exposed in Python through the `tf_big.Tensor` wrapper for convenience. For importing and exporting, numbers are typically expressed as strings.
 
 [![PyPI](https://img.shields.io/pypi/v/tf-big.svg)](https://pypi.org/project/tf-big/) [![CircleCI Badge](https://circleci.com/gh/tf-encrypted/tf-big/tree/master.svg?style=svg)](https://circleci.com/gh/tf-encrypted/tf-big/tree/master)
 

--- a/artifacts.py
+++ b/artifacts.py
@@ -1,0 +1,74 @@
+from collections import defaultdict
+import json
+import os
+
+from circleci.api import Api
+
+
+DESTDIR = os.environ.get('DESTDIR', None)
+CIRCLE_TOKEN = os.environ.get('CIRCLE_TOKEN', None)
+assert len(CIRCLE_TOKEN) >= 1, "Missing CIRCLE_TOKEN environment variable."
+
+
+circleci = Api(CIRCLE_TOKEN)
+
+def find_most_recent_deploy_builds(deploy_job_name_prefix='deploy-'):
+
+  all_recent_builds = circleci.get_project_build_summary(
+      username='tf-encrypted',
+      project='tf-big',
+      limit=50,
+      status_filter=None,
+      branch='master',
+      vcs_type='github',
+  )
+
+  commit_filter = None
+  most_recent_deploy_builds = list()
+
+  for build in all_recent_builds:
+    job_name = build['workflows']['job_name']
+    commit = build['all_commit_details'][0]['commit']
+
+    # skip all jobs we're not interested in
+    if not job_name.startswith(deploy_job_name_prefix):
+      continue
+
+    # we only want the most recent builds
+    if commit_filter is None:
+      # we have found our commit filter (first commit encountered)
+      commit_filter = commit
+    else:
+      # we have a commit filter, now apply it
+      if commit != commit_filter:
+        continue
+
+    most_recent_deploy_builds.append(build)
+
+  return most_recent_deploy_builds
+
+def download_artifacts_from_builds(builds, destdir=None):
+  for build in deploy_builds:
+    artifacts = circleci.get_artifacts(
+        username='tf-encrypted',
+        project='tf-big',
+        build_num=build['build_num'],
+        vcs_type='github',
+    )
+    print("Processing build {build_num} ({build_url}) committed at {committer_date} and stopped at {stop_time}".format(
+        build_num=build['build_num'],
+        committer_date=build['committer_date'],
+        stop_time=build['stop_time'],
+        build_url=build['build_url'],
+    ))
+    for artifact in artifacts:
+      print(" - Downloading artifact '{pretty_part}'".format(
+          pretty_part=artifact['pretty_path'],
+      ))
+      circleci.download_artifact(
+          url=artifact['url'],
+          destdir=destdir,
+      )
+
+deploy_builds = find_most_recent_deploy_builds()
+download_artifacts_from_builds(deploy_builds, destdir=DESTDIR)

--- a/artifacts.py
+++ b/artifacts.py
@@ -12,7 +12,7 @@ assert len(CIRCLE_TOKEN) >= 1, "Missing CIRCLE_TOKEN environment variable."
 
 circleci = Api(CIRCLE_TOKEN)
 
-def find_most_recent_deploy_builds(deploy_job_name_prefix='deploy-'):
+def find_most_recent_store_builds(store_job_name_prefix='store-'):
 
   all_recent_builds = circleci.get_project_build_summary(
       username='tf-encrypted',
@@ -24,14 +24,14 @@ def find_most_recent_deploy_builds(deploy_job_name_prefix='deploy-'):
   )
 
   commit_filter = None
-  most_recent_deploy_builds = list()
+  most_recent_store_builds = list()
 
   for build in all_recent_builds:
     job_name = build['workflows']['job_name']
     commit = build['all_commit_details'][0]['commit']
 
     # skip all jobs we're not interested in
-    if not job_name.startswith(deploy_job_name_prefix):
+    if not job_name.startswith(store_job_name_prefix):
       continue
 
     # we only want the most recent builds
@@ -43,12 +43,12 @@ def find_most_recent_deploy_builds(deploy_job_name_prefix='deploy-'):
       if commit != commit_filter:
         continue
 
-    most_recent_deploy_builds.append(build)
+    most_recent_store_builds.append(build)
 
-  return most_recent_deploy_builds
+  return most_recent_store_builds
 
 def download_artifacts_from_builds(builds, destdir=None):
-  for build in deploy_builds:
+  for build in builds:
     artifacts = circleci.get_artifacts(
         username='tf-encrypted',
         project='tf-big',
@@ -70,5 +70,5 @@ def download_artifacts_from_builds(builds, destdir=None):
           destdir=destdir,
       )
 
-deploy_builds = find_most_recent_deploy_builds()
-download_artifacts_from_builds(deploy_builds, destdir=DESTDIR)
+store_builds = find_most_recent_store_builds()
+download_artifacts_from_builds(store_builds, destdir=DESTDIR)


### PR DESCRIPTION
Adds a script for downloading artifacts from Circle CI, and pushing these to PyPI. This currently has to be done manually, ie running this from Circle CI is missing.