### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="tf-big",
-    version="0.1.2",
+    version="0.1.3",
     packages=setuptools.find_packages(),
     package_data={
         '': ['*.so'],


### PR DESCRIPTION
Debugging CircleCI used 0.1.2, which now seems blocked on PyPI. This PR bumps to 0.1.3.