### PR TITLE
tf-nightly fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,10 +348,10 @@ workflows:
   linux-py3.5:
     jobs:
       - build-linux:
-          name: build-linux-py3.5-tf2.2.0
+          name: build-linux-py3.5-tfnightly
           python-version: "3.5"
-          tensorflow-package: "tensorflow==2.2.0"
-          tensorflow-identifier: "tf2.2.0"
+          tensorflow-package: "tf-nightly"
+          tensorflow-identifier: "tfnightly"
           filters:
             branches:
               only: master
@@ -362,7 +362,7 @@ workflows:
           name: bundle-linux-py3.5
           python-version: "3.5"
           requires:
-            - build-linux-py3.5-tf2.2.0
+            - build-linux-py3.5-tfnightly
           filters:
             branches:
               only: master
@@ -370,9 +370,9 @@ workflows:
               only: /.*/
 
       - whltest-linux:
-          name: whltest-linux-py3.5-tf2.2.0
+          name: whltest-linux-py3.5-tfnightly
           python-version: "3.5"
-          tensorflow-package: "tensorflow==2.2.0"
+          tensorflow-package: "tf-nightly"
           requires:
             - bundle-linux-py3.5
           filters:
@@ -384,7 +384,7 @@ workflows:
       - store:
           name: store-linux-py3.5
           requires:
-            - whltest-linux-py3.5-tf2.2.0
+            - whltest-linux-py3.5-tfnightly
           filters:
             branches:
               only: master
@@ -415,10 +415,10 @@ workflows:
   linux-py3.6:
     jobs:
       - build-linux:
-          name: build-linux-py3.6-tf2.2.0
+          name: build-linux-py3.6-tfnightly
           python-version: "3.6"
-          tensorflow-package: "tensorflow==2.2.0"
-          tensorflow-identifier: "tf2.2.0"
+          tensorflow-package: "tf-nightly"
+          tensorflow-identifier: "tfnightly"
           filters:
             branches:
               only: master
@@ -429,7 +429,7 @@ workflows:
           name: bundle-linux-py3.6
           python-version: "3.6"
           requires:
-            - build-linux-py3.6-tf2.2.0
+            - build-linux-py3.6-tfnightly
           filters:
             branches:
               only: master
@@ -437,9 +437,9 @@ workflows:
               only: /.*/
 
       - whltest-linux:
-          name: whltest-linux-py3.6-tf2.2.0
+          name: whltest-linux-py3.6-tfnightly
           python-version: "3.6"
-          tensorflow-package: "tensorflow==2.2.0"
+          tensorflow-package: "tf-nightly"
           requires:
             - bundle-linux-py3.6
           filters:
@@ -451,7 +451,7 @@ workflows:
       - store:
           name: store-linux-py3.6
           requires:
-            - whltest-linux-py3.6-tf2.2.0
+            - whltest-linux-py3.6-tfnightly
           filters:
             branches:
               only: master
@@ -482,10 +482,10 @@ workflows:
   macos-py3.6:
     jobs:
       - build-macos:
-          name: build-macos-py3.6-tf2.2.0
+          name: build-macos-py3.6-tfnightly
           python-version: "3.6"
-          tensorflow-package: "tensorflow==2.2.0"
-          tensorflow-identifier: "tf2.2.0"
+          tensorflow-package: "tf-nightly"
+          tensorflow-identifier: "tfnightly"
           filters:
             branches:
               only: master
@@ -496,7 +496,7 @@ workflows:
           name: bundle-macos-py3.6
           python-version: "3.6"
           requires:
-            - build-macos-py3.6-tf2.2.0
+            - build-macos-py3.6-tfnightly
           filters:
             branches:
               only: master
@@ -504,9 +504,9 @@ workflows:
               only: /.*/
 
       - whltest-macos:
-          name: whltest-macos-py3.6-tf2.2.0
+          name: whltest-macos-py3.6-tfnightly
           python-version: "3.6"
-          tensorflow-package: "tensorflow==2.2.0"
+          tensorflow-package: "tf-nightly"
           requires:
             - bundle-macos-py3.6
           filters:
@@ -518,7 +518,7 @@ workflows:
       - store:
           name: store-macos-py3.6
           requires:
-            - whltest-macos-py3.6-tf2.2.0
+            - whltest-macos-py3.6-tfnightly
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,9 +348,10 @@ workflows:
   linux-py3.5:
     jobs:
       - build-linux:
-          name: build-linux-py3.5-tf2.1.0
+          name: build-linux-py3.5-tf2.2.0
           python-version: "3.5"
-          tensorflow-version: "2.1.0"
+          tensorflow-package: "tensorflow==2.2.0"
+          tensorflow-identifier: "tf2.2.0"
           filters:
             branches:
               only: master
@@ -361,7 +362,7 @@ workflows:
           name: bundle-linux-py3.5
           python-version: "3.5"
           requires:
-            - build-linux-py3.5-tf2.1.0
+            - build-linux-py3.5-tf2.2.0
           filters:
             branches:
               only: master
@@ -369,9 +370,9 @@ workflows:
               only: /.*/
 
       - whltest-linux:
-          name: whltest-linux-py3.5-tf2.1.0
+          name: whltest-linux-py3.5-tf2.2.0
           python-version: "3.5"
-          tensorflow-version: "2.1.0"
+          tensorflow-package: "tensorflow==2.2.0"
           requires:
             - bundle-linux-py3.5
           filters:
@@ -383,7 +384,7 @@ workflows:
       - store:
           name: store-linux-py3.5
           requires:
-            - whltest-linux-py3.5-tf2.1.0
+            - whltest-linux-py3.5-tf2.2.0
           filters:
             branches:
               only: master
@@ -414,9 +415,10 @@ workflows:
   linux-py3.6:
     jobs:
       - build-linux:
-          name: build-linux-py3.6-tf2.1.0
+          name: build-linux-py3.6-tf2.2.0
           python-version: "3.6"
-          tensorflow-version: "2.1.0"
+          tensorflow-package: "tensorflow==2.2.0"
+          tensorflow-identifier: "tf2.2.0"
           filters:
             branches:
               only: master
@@ -427,7 +429,7 @@ workflows:
           name: bundle-linux-py3.6
           python-version: "3.6"
           requires:
-            - build-linux-py3.6-tf2.1.0
+            - build-linux-py3.6-tf2.2.0
           filters:
             branches:
               only: master
@@ -435,9 +437,9 @@ workflows:
               only: /.*/
 
       - whltest-linux:
-          name: whltest-linux-py3.6-tf2.1.0
+          name: whltest-linux-py3.6-tf2.2.0
           python-version: "3.6"
-          tensorflow-version: "2.1.0"
+          tensorflow-package: "tensorflow==2.2.0"
           requires:
             - bundle-linux-py3.6
           filters:
@@ -449,7 +451,7 @@ workflows:
       - store:
           name: store-linux-py3.6
           requires:
-            - whltest-linux-py3.6-tf2.1.0
+            - whltest-linux-py3.6-tf2.2.0
           filters:
             branches:
               only: master
@@ -480,9 +482,10 @@ workflows:
   macos-py3.6:
     jobs:
       - build-macos:
-          name: build-macos-py3.6-tf2.1.0
+          name: build-macos-py3.6-tf2.2.0
           python-version: "3.6"
-          tensorflow-version: "2.1.0"
+          tensorflow-package: "tensorflow==2.2.0"
+          tensorflow-identifier: "tf2.2.0"
           filters:
             branches:
               only: master
@@ -493,7 +496,7 @@ workflows:
           name: bundle-macos-py3.6
           python-version: "3.6"
           requires:
-            - build-macos-py3.6-tf2.1.0
+            - build-macos-py3.6-tf2.2.0
           filters:
             branches:
               only: master
@@ -501,9 +504,9 @@ workflows:
               only: /.*/
 
       - whltest-macos:
-          name: whltest-macos-py3.6-tf2.1.0
+          name: whltest-macos-py3.6-tf2.2.0
           python-version: "3.6"
-          tensorflow-version: "2.1.0"
+          tensorflow-package: "tensorflow==2.2.0"
           requires:
             - bundle-macos-py3.6
           filters:
@@ -515,7 +518,7 @@ workflows:
       - store:
           name: store-macos-py3.6
           requires:
-            - whltest-macos-py3.6-tf2.1.0
+            - whltest-macos-py3.6-tf2.2.0
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,9 @@ commands:
     parameters:
       python-version:
         type: string
-      tensorflow-version:
+      tensorflow-package:
+        type: string
+      tensorflow-identifier:
         type: string
       # next parameter should be derived 
       python-environment:
@@ -51,11 +53,11 @@ commands:
             pip install -q -U -r requirements-dev.txt
             pip freeze
       - run:
-          name: Install TensorFlow << parameters.tensorflow-version >> in '<< parameters.python-environment >>'
+          name: Install << parameters.tensorflow-package >> in '<< parameters.python-environment >>'
           command: |
             . << parameters.python-environment >>/bin/activate
             make clean
-            pip install -q -U tensorflow==<< parameters.tensorflow-version >>
+            pip install -q -U << parameters.tensorflow-package >>
             make .bazelrc
             # reduce Bazel output to logs
             echo 'test --noshow_progress --noshow_loading_progress' >> .bazelrc
@@ -73,11 +75,11 @@ commands:
             . << parameters.python-environment >>/bin/activate
             python --version
             pip freeze
-            DIR_TAGGED=./out/builds/py<< parameters.python-version >>-tf<< parameters.tensorflow-version >> make build
+            DIR_TAGGED=./out/builds/py<< parameters.python-version >>-<< parameters.tensorflow-identifier >> make build
       - persist_to_workspace:
           root: ./out
           paths:
-            - builds/py<< parameters.python-version >>-tf<< parameters.tensorflow-version >>
+            - builds/py<< parameters.python-version >>-<< parameters.tensorflow-identifier >>
   
   bundle:
     parameters:
@@ -121,7 +123,7 @@ commands:
     parameters:
       python-version:
         type: string
-      tensorflow-version:
+      tensorflow-package:
         type: string
       python-environment:
         type: string
@@ -132,7 +134,7 @@ commands:
       - attach_workspace:
           at: ./out
       - run:
-          name: Configure '<< parameters.python-environment >>' to use TensorFlow << parameters.tensorflow-version >>
+          name: Configure '<< parameters.python-environment >>' to use << parameters.tensorflow-package >>
           command: |
             set -e
             set -x
@@ -149,7 +151,7 @@ commands:
             # install the package, but forced to only use the wheelhouse
             pip install -U tf-big --no-deps --no-cache-dir --no-index --find-links ./out/wheelhouse
             # make sure we are testing against the right version of TensorFlow
-            pip install -q -U tensorflow==<< parameters.tensorflow-version >>
+            pip install -q -U << parameters.tensorflow-package >>
       - run:
           name: Test wheel in '<< parameters.python-environment >>'
           command: |
@@ -164,7 +166,9 @@ jobs:
     parameters:
       python-version:
         type: string
-      tensorflow-version:
+      tensorflow-package:
+        type: string
+      tensorflow-identifier:
         type: string
     docker:
       - image: tfencrypted/tf-big:build
@@ -173,14 +177,17 @@ jobs:
       - checkout
       - build:
           python-version: << parameters.python-version >>
-          tensorflow-version: << parameters.tensorflow-version >>
-          python-environment: build-linux-py<< parameters.python-version >>-tf<< parameters.tensorflow-version >>
+          tensorflow-package: << parameters.tensorflow-package >>
+          tensorflow-identifier: << parameters.tensorflow-identifier >>
+          python-environment: build-linux-py<< parameters.python-version >>-<< parameters.tensorflow-identifier >>
 
   build-macos:
     parameters:
       python-version:
         type: string
-      tensorflow-version:
+      tensorflow-package:
+        type: string
+      tensorflow-identifier:
         type: string
     macos:
       xcode: "10.0.0"
@@ -190,8 +197,9 @@ jobs:
       - bootstrap-macos
       - build:
           python-version: << parameters.python-version >>
-          tensorflow-version: << parameters.tensorflow-version >>
-          python-environment: build-macos-py<< parameters.python-version >>-tf<< parameters.tensorflow-version >>
+          tensorflow-package: << parameters.tensorflow-package >>
+          tensorflow-identifier: << parameters.tensorflow-identifier >>
+          python-environment: build-macos-py<< parameters.python-version >>-<< parameters.tensorflow-identifier >>
 
   bundle-linux:
     parameters:
@@ -224,7 +232,7 @@ jobs:
     parameters:
       python-version:
         type: string
-      tensorflow-version:
+      tensorflow-package:
         type: string
     docker:
       - image: tfencrypted/tf-big:whltest
@@ -234,13 +242,13 @@ jobs:
       - whltest:
           python-version: << parameters.python-version >>
           python-environment: test-linux-py<< parameters.python-version >>
-          tensorflow-version: << parameters.tensorflow-version >>
+          tensorflow-package: << parameters.tensorflow-package >>
 
   whltest-macos:
     parameters:
       python-version:
         type: string
-      tensorflow-version:
+      tensorflow-package:
         type: string
     macos:
       xcode: "10.0.0"
@@ -251,7 +259,7 @@ jobs:
       - whltest:
           python-version: << parameters.python-version >>
           python-environment: test-macos-py<< parameters.python-version >>
-          tensorflow-version: << parameters.tensorflow-version >>
+          tensorflow-package: << parameters.tensorflow-package >>
 
   store:
     docker:
@@ -304,9 +312,10 @@ workflows:
   quicktest:
     jobs:
       - build-linux:
-          name: build-linux-py3.6-tf2.1.0
+          name: build-linux-py3.6-tfnightly
           python-version: "3.6"
-          tensorflow-version: "2.1.0"
+          tensorflow-package: "tf-nightly"
+          tensorflow-identifier: "tfnightly"
           filters:
             branches:
               ignore: master
@@ -317,7 +326,7 @@ workflows:
           name: bundle-linux-py3.6
           python-version: "3.6"
           requires:
-            - build-linux-py3.6-tf2.1.0
+            - build-linux-py3.6-tfnightly
           filters:
             branches:
               ignore: master
@@ -325,9 +334,9 @@ workflows:
               ignore: /.*/
 
       - whltest-linux:
-          name: whltest-linux-py3.6-tf2.1.0
+          name: whltest-linux-py3.6-tfnightly
           python-version: "3.6"
-          tensorflow-version: "2.1.0"
+          tensorflow-package: "tf-nightly"
           requires:
             - bundle-linux-py3.6
           filters:

--- a/build.sh
+++ b/build.sh
@@ -17,12 +17,6 @@ OUT=${1}
 bazel clean
 bazel build :build_sh
 
-# tag .so files in build with current TensorFlow version
-TF_VERSION=`python -c "import tensorflow; print(tensorflow.__version__)"`
-pushd ./bazel-bin/build_sh.runfiles/__main__/tf_big
-mmv ";*.so" "#1#2_${TF_VERSION}.so"
-popd
-
 # copy out files to destination
 rsync -avm \
   --exclude "_solib*" \

--- a/configure.sh
+++ b/configure.sh
@@ -61,24 +61,8 @@ if [[ "$TF_NEED_CUDA" == "0" ]]; then
   if [[ $(pip show tensorflow) == *tensorflow* ]] || [[ $(pip show tf-nightly) == *tf-nightly* ]] ; then
     echo 'Using installed tensorflow'
   else
-    # Uninstall GPU version if it is installed.
-    if [[ $(pip show tensorflow-gpu) == *tensorflow-gpu* ]]; then
-      echo 'Already have gpu version of tensorflow installed. Uninstalling......\n'
-      pip uninstall tensorflow-gpu
-    elif [[ $(pip show tf-nightly-gpu) == *tf-nightly-gpu* ]]; then
-      echo 'Already have gpu version of tensorflow installed. Uninstalling......\n'
-      pip uninstall tf-nightly-gpu
-    fi
-    # Install CPU version
-    echo 'Installing tensorflow......\n'
-    if is_linux ; then
-        # (Dragos) need to upgrade tf_big class to work with tstring to work on latest tf 2.2
-        # see this changelog: https://github.com/google/sentencepiece/commit/3d98bcd122ca6c547ac98c1298a596f85a468eb4
-        pip install --upgrade pip
-        pip install tensorflow==2.1.0
-     else
-        pip install tensorflow
-    fi
+    echo "Error: expected tensorflow to be installed before running configure.sh."
+    exit 1
   fi
 fi
 

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:2.1.0-custom-op-ubuntu16
+FROM tensorflow/tensorflow:nightly-custom-op-ubuntu16
 
 # Install tools needed for building
 RUN apt update && \

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:nightly-custom-op-ubuntu16
+FROM tensorflow/tensorflow:custom-op-ubuntu16
 
 # Install tools needed for building
 RUN apt update && \

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setuptools.setup(
     install_requires=[
         "pip>=20.1.1",
         "numpy >=1.14",
-        "tensorflow ==2.1.0",
     ],
     extras_require={
         "tf": ["tensorflow ==2.1.0"],

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,11 @@ setuptools.setup(
     python_requires=">=3.5",
     install_requires=[
         "pip>=20.1.1",
-        "numpy >=1.14",
+        "numpy>=1.14",
     ],
     extras_require={
-        "tf": ["tensorflow ==2.1.0"],
+        "tf": ["tensorflow~=2.2.0"],
+        "nightly": ["tf-nightly"]
     },
     license="Apache License 2.0",
     url="https://github.com/tf-encrypted/tf-big",

--- a/tf_big/cc/big_tensor.cc
+++ b/tf_big/cc/big_tensor.cc
@@ -21,7 +21,7 @@ void BigTensor::Encode(VariantTensorData* data) const {
   auto shape = TensorShape{rows, cols};
   Tensor t(DT_STRING, shape);
 
-  auto mat = t.matrix<string>();
+  auto mat = t.matrix<tstring>();
   for (int i = 0; i < rows; i++) {
     for (int j = 0; j < cols; j++) {
       size_t count_p;
@@ -31,7 +31,7 @@ void BigTensor::Encode(VariantTensorData* data) const {
 
       int total_size = count_p * sizeof(int32);
 
-      mat(i, j) = string(p, total_size);
+      mat(i, j) = tstring(p, total_size);
     }
   }
 
@@ -45,7 +45,7 @@ bool BigTensor::Decode(const VariantTensorData& data) {
     return false;
   }
 
-  auto mat = data.tensors()[0].matrix<string>();
+  auto mat = data.tensors()[0].matrix<tstring>();
 
   auto rows = data.tensors()[0].dim_size(0);
   auto cols = data.tensors()[0].dim_size(1);

--- a/tf_big/cc/big_tensor.h
+++ b/tf_big/cc/big_tensor.h
@@ -162,13 +162,13 @@ inline void BigTensor::ToTensor<int32>(Tensor* t) const {
 }
 
 template <>
-inline void BigTensor::FromTensor<string>(const Tensor& t) {
+inline void BigTensor::FromTensor<tstring>(const Tensor& t) {
   auto rows = t.dim_size(0);
   auto cols = t.dim_size(1);
 
   value = MatrixXm(rows, cols);
 
-  auto mat = t.matrix<string>();
+  auto mat = t.matrix<tstring>();
   for (int i = 0; i < rows; i++) {
     for (int j = 0; j < cols; j++) {
       value(i, j) = mpz_class(mat(i, j), 10);

--- a/tf_big/cc/kernels/big_kernels.cc
+++ b/tf_big/cc/kernels/big_kernels.cc
@@ -377,15 +377,15 @@ class BigRandomRsaModulusOp : public OpKernel {
 REGISTER_UNARY_VARIANT_DECODE_FUNCTION(BigTensor, BigTensor::kTypeName);
 
 REGISTER_KERNEL_BUILDER(
-    Name("BigImport").Device(DEVICE_CPU).TypeConstraint<string>("dtype"),
-    BigImportOp<string>);
+    Name("BigImport").Device(DEVICE_CPU).TypeConstraint<tstring>("dtype"),
+    BigImportOp<tstring>);
 REGISTER_KERNEL_BUILDER(
     Name("BigImport").Device(DEVICE_CPU).TypeConstraint<int32>("dtype"),
     BigImportOp<int32>);
 
 REGISTER_KERNEL_BUILDER(
-    Name("BigExport").Device(DEVICE_CPU).TypeConstraint<string>("dtype"),
-    BigExportOp<string>);
+    Name("BigExport").Device(DEVICE_CPU).TypeConstraint<tstring>("dtype"),
+    BigExportOp<tstring>);
 REGISTER_KERNEL_BUILDER(
     Name("BigExport").Device(DEVICE_CPU).TypeConstraint<int32>("dtype"),
     BigExportOp<int32>);

--- a/tf_big/cc/kernels/big_kernels.cc
+++ b/tf_big/cc/kernels/big_kernels.cc
@@ -3,6 +3,7 @@
 #include "tensorflow/core/framework/op.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/shape_inference.h"
+#include "tensorflow/core/framework/tensor_util.h"
 #include "tensorflow/core/framework/variant.h"
 #include "tensorflow/core/framework/variant_encode_decode.h"
 #include "tensorflow/core/framework/variant_op_registry.h"
@@ -286,7 +287,7 @@ class BigRandomUniformOp : public OpKernel {
   void Compute(OpKernelContext* ctx) override {
     const Tensor& shape_tensor = ctx->input(0);
     TensorShape shape;
-    OP_REQUIRES_OK(ctx, MakeShape(shape_tensor, &shape));
+    OP_REQUIRES_OK(ctx, tensor::MakeShape(shape_tensor, &shape));
 
     const BigTensor* maxval_tensor = nullptr;
     OP_REQUIRES_OK(ctx, GetBigTensor(ctx, 1, &maxval_tensor));

--- a/tf_big/python/ops/big_ops.py
+++ b/tf_big/python/ops/big_ops.py
@@ -1,46 +1,10 @@
-import logging
-
-import tensorflow
-from tensorflow.python.framework import load_library
+import tensorflow as tf
 from tensorflow.python.framework.errors import NotFoundError
 from tensorflow.python.platform import resource_loader
 
 
-
-logger = logging.getLogger()
-
-
-def try_load_library(base_filename):
-
-  def try_load(op_lib_filename):
-    try:
-      op_lib_file = resource_loader.get_path_to_datafile(op_lib_filename)
-      big_ops = load_library.load_op_library(op_lib_file)
-      return big_ops
-    except NotFoundError as e:
-      logger.debug(e)
-    except:
-      logger.debug("Unknown error loading .so file")
-    return None
-
-  # try version specific file
-  big_ops = try_load("{}_{}.so".format(base_filename, tensorflow.__version__))
-  if big_ops is not None:
-      return big_ops
-
-  logger.warning(("Could not load version specific .so file for '{}', "
-                  "trying version neutral .so file").format(base_filename))
-
-  # try version neutral file
-  big_ops = try_load("{}.so".format(base_filename))
-  if big_ops is not None:
-      return big_ops
-
-  logger.error("Could not load .so file")
-  return None
-
-
-big_ops = try_load_library('_big_ops')
+big_ops_libfile = resource_loader.get_path_to_datafile("_big_ops.so")
+big_ops = tf.load_op_library(big_ops_libfile)
 
 big_import = big_ops.big_import
 big_export = big_ops.big_export

--- a/tf_big/python/tensor.py
+++ b/tf_big/python/tensor.py
@@ -9,6 +9,7 @@ from tensorflow.python.framework import ops as tf_ops
 
 
 class Tensor(object):
+  is_tensor_like = True  # needed to pass tf.is_tensor, new as of TF 2.2+
 
   def __init__(self, value):
     assert isinstance(value, tf.Tensor), type(value)
@@ -133,10 +134,6 @@ def _tensor_conversion_function(tensor, dtype=None, name=None, as_ref=False):
 # but since the output dtype is determined by the outer context
 # we essentially have to export with the implied risk of data loss
 tf_ops.register_tensor_conversion_function(Tensor, _tensor_conversion_function)
-
-
-# this allows Tensor to pass the tf.is_tensor test
-tf_ops.register_dense_tensor_like_type(Tensor)
 
 
 # this allows tf_big.Tensor to be plumbed through Keras layers


### PR DESCRIPTION
Closes capeprivacy/planning#1332

Updates the package to work with the current tf-nightly version `2.5.0.dev20200626`. We should discuss whether this is the right version to upgrade to, or if we should also test/release our current master branch against earlier versions (2.2+). After discussion, we can update CI with the correct base image.

Primary changes:
- The previous Tensor-like object registry is gone; the new way of passing a `tf.is_tensor` check is to include an attribute `is_tensor_like` that evaluates to True. I've added this as a class attribute to `tf_big.Tensor`
- Using `string` in `OpKernel::Compute` is no longer supported, and is replaced by `tensorflow::tstring`