### PR TITLE
improve user control over limb format options

### DIFF
--- a/tf_big/python/tensor.py
+++ b/tf_big/python/tensor.py
@@ -234,12 +234,16 @@ def _convert_tensorflow_tensor(tensor, bitlength, limb_format):
   raise ValueError("Don't know how to convert TensorFlow tensor with dtype '{}'".format(tensor.dtype))
 
 
-def convert_to_tensor(tensor, bitlength=None, limb_format=False):
+def convert_to_tensor(tensor, limb_format=False, bitlength=None):
   assert isinstance(limb_format, bool), type(limb_format)
   if bitlength is not None and not isinstance(bitlength, int):
     raise ValueError(
         "Optional bitlength kwarg must be an integer, "
         "got {}.".format(type(bitlength)))
+  if limb_format and bitlength is None:
+    raise ValueError(
+        "Bitlength is a required argument whenever limb_format=True."
+    )
 
   if isinstance(tensor, Tensor):
     return tensor
@@ -281,6 +285,9 @@ def convert_from_tensor(value, dtype=None, limb_format=False, bitlength=None):
       dtype = tf.int32
 
     return ops.big_export_limbs(bitlength, value._raw, dtype=dtype)
+
+  if bitlength is not None:
+    raise ValueError("Passing explicit bitlength has no effect when limb_format=False.")
 
   if dtype is None:
     dtype = tf.string

--- a/tf_big/python/tensor_test.py
+++ b/tf_big/python/tensor_test.py
@@ -287,20 +287,20 @@ class ConvertTest(parameterized.TestCase):
     context = tf_execution_context(run_eagerly)
 
     with context.scope():
-      x = convert_to_tensor(np.array([[10, 20]]))
+      x = convert_to_tensor(np.array([[10, 20]]), bitlength=16)
       assert x.shape.as_list() == [1, 2], x.shape
-      x_limbs = convert_from_tensor(x, dtype=tf_type, limb_format=True, max_bitlen=16)
+      x_limbs = convert_from_tensor(x, dtype=tf_type, limb_format=True)
       assert x_limbs.shape.as_list() == x.shape.as_list() + (
           [tf_shape] if run_eagerly else [None]), x_limbs.shape
-      x_norm = convert_to_tensor(x_limbs, limb_format=True)
+      x_norm = convert_to_tensor(x_limbs, bitlength=16, limb_format=True)
       assert x_norm.shape.as_list() == x.shape.as_list(), x_norm.shape
 
-      y = convert_to_tensor(np.array([[30, 40]]))
+      y = convert_to_tensor(np.array([[30, 40]]), bitlength=16)
       assert y.shape.as_list() == [1, 2], y.shape
-      y_limbs = convert_from_tensor(y, dtype=tf_type, limb_format=True, max_bitlen=16)
+      y_limbs = convert_from_tensor(y, dtype=tf_type, limb_format=True)
       assert y_limbs.shape.as_list() == y.shape.as_list() + (
           [tf_shape] if run_eagerly else [None]), y_limbs.shape
-      y_norm = convert_to_tensor(y_limbs, limb_format=True) 
+      y_norm = convert_to_tensor(y_limbs, bitlength=16, limb_format=True)
       assert y_norm.shape.as_list() == y.shape.as_list(), y_norm.shape
 
       z = x_norm + y_norm


### PR DESCRIPTION
- Moved bitlength as a passable kwarg to tf_big.Tensor constructor;  this allows users to specify the bitlength on data input, e.g. to avoid keeping track of it later on). If bitlength would change during GMP computation, users can explicitly override the old bitlength during data export.
- Added a bit of arg/kwarg sanitization to this part of the code
- Cleaned up some implementation details
- Updated tests