### PR TITLE
Revert "improve user control over limb format options"

### DIFF
--- a/tf_big/python/tensor.py
+++ b/tf_big/python/tensor.py
@@ -11,19 +11,10 @@ from tensorflow.python.framework import ops as tf_ops
 class Tensor(object):
   is_tensor_like = True  # needed to pass tf.is_tensor, new as of TF 2.2+
 
-  def __init__(self, value, bitlength=None):
+  def __init__(self, value):
     assert isinstance(value, tf.Tensor), type(value)
     assert value.dtype is tf.variant, value.dtype
     self._raw = value
-    if bitlength is not None:
-      assert isinstance(bitlength, int), type(bitlength)
-      self._bitlength = bitlength
-    else:
-      self._bitlength = bitlength
-
-  @property
-  def bitlength(self):
-    return self._bitlength
 
   @property
   def shape(self):
@@ -36,7 +27,6 @@ class Tensor(object):
   @property
   def dtype(self):
     return tf.int32
-    # TODO check if future TF versions (2.x.x) resolve this issue
     # return tf.string
 
   def eval(self, session=None, dtype=None):
@@ -157,40 +147,35 @@ def constant(tensor):
   return convert_to_tensor(tensor)
 
 
-def _numpy_limbs_to_tensor(tensor, bitlength):
-  assert bitlength is not None
+
+def _numpy_limbs_to_tensor(tensor):
   if len(tensor.shape) < 2:
     raise ValueError("Tensor must have at least a 2D shape when given in GMP format.")
 
   if np.issubdtype(tensor.dtype, np.int32) \
     or np.issubdtype(tensor.dtype, np.uint8):
-    return Tensor(ops.big_import_limbs(tensor), bitlength=bitlength)
+    return Tensor(ops.big_import_limbs(tensor))
   else:
-    raise ValueError(
-        "Failed limb conversion for {}, input dtype must be subtype of "
-        "np.int32 or np.uint8".format(tensor.dtype))
+    raise ValueError("Not implemented limb conversion for this type")
 
 
-def _tensor_limbs_to_tensor(tensor, bitlength):
-  assert bitlength is not None
+def _tensor_limbs_to_tensor(tensor):
   if len(tensor.shape) < 2:
     raise ValueError("Tensor must have at least a 2D shape when given in GMP format.")
 
   if tensor.dtype in (tf.uint8, tf.int32):
-    return Tensor(ops.big_import_limbs(tensor), bitlength=bitlength)
+    return Tensor(ops.big_import_limbs(tensor))
   else:
-    raise ValueError(
-        "Failed limb conversion for {}, input dtype must be "
-        "tf.int32 or tf.uint8".format(tensor.dtype))
+    raise ValueError("Not implemented limb conversion")
 
 
-def _convert_numpy_tensor(tensor, bitlength, limb_format):
-  if limb_format:
-    return _numpy_limbs_to_tensor(tensor, bitlength)
+def _convert_numpy_tensor(tensor, limb_format=False):
+  if limb_format is True:
+    return _numpy_limbs_to_tensor(tensor)
 
   if len(tensor.shape) > 2:
     raise ValueError("Only matrices are supported for now.")
-
+    
   # make sure we have a full matrix
   while len(tensor.shape) < 2:
     tensor = np.expand_dims(tensor, 0)
@@ -199,21 +184,21 @@ def _convert_numpy_tensor(tensor, bitlength, limb_format):
      or np.issubdtype(tensor.dtype, np.string_) \
      or np.issubdtype(tensor.dtype, np.unicode_):
     # supported as-is
-    return Tensor(ops.big_import(tensor), bitlength=bitlength)
+    return Tensor(ops.big_import(tensor))
 
   if np.issubdtype(tensor.dtype, np.int64) \
      or np.issubdtype(tensor.dtype, np.object_):
     # supported as strings
     tensor = tensor.astype(np.string_)
-    return Tensor(ops.big_import(tensor), bitlength=bitlength)
+    return Tensor(ops.big_import(tensor))
   
   raise ValueError("Don't know how to convert NumPy tensor with dtype '{}'".format(tensor.dtype))
 
 
-def _convert_tensorflow_tensor(tensor, bitlength, limb_format):
+def _convert_tensorflow_tensor(tensor, limb_format=False):
 
-  if limb_format:
-    return _tensor_limbs_to_tensor(tensor, bitlength)
+  if limb_format is True:
+    return _tensor_limbs_to_tensor(tensor)
 
   if len(tensor.shape) > 2:
     raise ValueError("Only matrices are supported for now.")
@@ -224,23 +209,17 @@ def _convert_tensorflow_tensor(tensor, bitlength, limb_format):
 
   if tensor.dtype in (tf.int32, tf.string, tf.uint8):
     # supported as-is
-    return Tensor(ops.big_import(tensor), bitlength=bitlength)
+    return Tensor(ops.big_import(tensor))
 
   if tensor.dtype in (tf.int64, ):
     # supported as strings
     tensor = tf.as_string(tensor)
-    return Tensor(ops.big_import(tensor), bitlength=bitlength)
+    return Tensor(ops.big_import(tensor))
 
   raise ValueError("Don't know how to convert TensorFlow tensor with dtype '{}'".format(tensor.dtype))
 
 
-def convert_to_tensor(tensor, bitlength=None, limb_format=False):
-  assert isinstance(limb_format, bool), type(limb_format)
-  if bitlength is not None and not isinstance(bitlength, int):
-    raise ValueError(
-        "Optional bitlength kwarg must be an integer, "
-        "got {}.".format(type(bitlength)))
-
+def convert_to_tensor(tensor, limb_format=False):
   if isinstance(tensor, Tensor):
     return tensor
 
@@ -248,42 +227,29 @@ def convert_to_tensor(tensor, bitlength=None, limb_format=False):
     return None
 
   if isinstance(tensor, (int, str)):
-    return _convert_numpy_tensor(np.array([tensor]), bitlength, limb_format)
+    return _convert_numpy_tensor(np.array([tensor]), limb_format)
 
   if isinstance(tensor, (list, tuple)):
-    return _convert_numpy_tensor(np.array(tensor), bitlength, limb_format)
+    return _convert_numpy_tensor(np.array(tensor), limb_format)
 
   if isinstance(tensor, np.ndarray):
-    return _convert_numpy_tensor(tensor, bitlength, limb_format)
+    return _convert_numpy_tensor(tensor, limb_format)
 
   if isinstance(tensor, tf.Tensor):
-    return _convert_tensorflow_tensor(tensor, bitlength, limb_format)
+    return _convert_tensorflow_tensor(tensor, limb_format)
 
   raise ValueError("Don't know how to convert value of type {}".format(type(tensor)))
 
 
-def convert_from_tensor(value, dtype=None, limb_format=False, bitlength=None):
+def convert_from_tensor(value, dtype=None, limb_format=False, max_bitlen=None):
   assert isinstance(value, Tensor), type(value)
-  assert isinstance(limb_format, bool), type(limb_format)
-
-  if limb_format:
-
-    if bitlength is not None:
-      assert isinstance(bitlength, int), type(bitlength)
-      assert bitlength > 0
-      bitlength_to_check = value.bitlength or -1
-      assert bitlength_to_check <= bitlength
-    elif value.bitlength is not None:
-      bitlength = value.bitlength
-    else:
-      raise ValueError("No bitlength provided for input tensor, cannot export in limb format.")
-    if dtype is None:
-      dtype = tf.int32
-
-    return ops.big_export_limbs(bitlength, value._raw, dtype=dtype)
 
   if dtype is None:
     dtype = tf.string
+
+  if limb_format is True:
+    assert max_bitlen != None
+    return ops.big_export_limbs(max_bitlen, value._raw, dtype)
 
   if dtype in [tf.int32, tf.string]:
     return ops.big_export(value._raw, dtype=dtype)

--- a/tf_big/python/tensor.py
+++ b/tf_big/python/tensor.py
@@ -234,16 +234,12 @@ def _convert_tensorflow_tensor(tensor, bitlength, limb_format):
   raise ValueError("Don't know how to convert TensorFlow tensor with dtype '{}'".format(tensor.dtype))
 
 
-def convert_to_tensor(tensor, limb_format=False, bitlength=None):
+def convert_to_tensor(tensor, bitlength=None, limb_format=False):
   assert isinstance(limb_format, bool), type(limb_format)
   if bitlength is not None and not isinstance(bitlength, int):
     raise ValueError(
         "Optional bitlength kwarg must be an integer, "
         "got {}.".format(type(bitlength)))
-  if limb_format and bitlength is None:
-    raise ValueError(
-        "Bitlength is a required argument whenever limb_format=True."
-    )
 
   if isinstance(tensor, Tensor):
     return tensor
@@ -285,9 +281,6 @@ def convert_from_tensor(value, dtype=None, limb_format=False, bitlength=None):
       dtype = tf.int32
 
     return ops.big_export_limbs(bitlength, value._raw, dtype=dtype)
-
-  if bitlength is not None:
-    raise ValueError("Passing explicit bitlength has no effect when limb_format=False.")
 
   if dtype is None:
     dtype = tf.string

--- a/tf_big/python/tensor_test.py
+++ b/tf_big/python/tensor_test.py
@@ -287,20 +287,20 @@ class ConvertTest(parameterized.TestCase):
     context = tf_execution_context(run_eagerly)
 
     with context.scope():
-      x = convert_to_tensor(np.array([[10, 20]]), bitlength=16)
+      x = convert_to_tensor(np.array([[10, 20]]))
       assert x.shape.as_list() == [1, 2], x.shape
-      x_limbs = convert_from_tensor(x, dtype=tf_type, limb_format=True)
+      x_limbs = convert_from_tensor(x, dtype=tf_type, limb_format=True, max_bitlen=16)
       assert x_limbs.shape.as_list() == x.shape.as_list() + (
           [tf_shape] if run_eagerly else [None]), x_limbs.shape
-      x_norm = convert_to_tensor(x_limbs, bitlength=16, limb_format=True)
+      x_norm = convert_to_tensor(x_limbs, limb_format=True)
       assert x_norm.shape.as_list() == x.shape.as_list(), x_norm.shape
 
-      y = convert_to_tensor(np.array([[30, 40]]), bitlength=16)
+      y = convert_to_tensor(np.array([[30, 40]]))
       assert y.shape.as_list() == [1, 2], y.shape
-      y_limbs = convert_from_tensor(y, dtype=tf_type, limb_format=True)
+      y_limbs = convert_from_tensor(y, dtype=tf_type, limb_format=True, max_bitlen=16)
       assert y_limbs.shape.as_list() == y.shape.as_list() + (
           [tf_shape] if run_eagerly else [None]), y_limbs.shape
-      y_norm = convert_to_tensor(y_limbs, bitlength=16, limb_format=True)
+      y_norm = convert_to_tensor(y_limbs, limb_format=True) 
       assert y_norm.shape.as_list() == y.shape.as_list(), y_norm.shape
 
       z = x_norm + y_norm


### PR DESCRIPTION
Reverts tf-encrypted/tf-big#73, replaced by https://github.com/tf-encrypted/tf-big/pull/74